### PR TITLE
Fix URL underlining color

### DIFF
--- a/GOG-Dark.user.css
+++ b/GOG-Dark.user.css
@@ -690,6 +690,9 @@ img[src="https://items.gog.com/separator.jpg"] {
 .article-section__title, .article__secondary_title {
 	color: var(--text2);
 }
+.article__body a {
+	background-image: linear-gradient(90deg,var(--text1),var(--text1));
+}
 .article__body, .article__body p {
 	color: var(--text1);
 }


### PR DESCRIPTION
https://www.gog.com/news/weekend_sale_games_filled_with_action_up_to_90_off
![1](https://user-images.githubusercontent.com/14265316/124295660-c6e2e000-db61-11eb-9de5-2246095d9cf6.png)