### PR TITLE
Fix "Not eligible for redeem" text color

### DIFF
--- a/GOG-Dark.user.css
+++ b/GOG-Dark.user.css
@@ -823,7 +823,7 @@ img[src="https://items.gog.com/separator.jpg"] {
 	color: var(--text2);
 	background: #2d2d2d;
 }
-.select-products-text[data-v-76553c1e], .title[data-v-3ef69486], .price__final[data-v-3ef69486], .operating-system[data-v-3ef69486], .gifter-text[data-v-76553c1e], .user[data-v-41926b43] {
+.not-eligible-text[data-v-08e189b5], .select-products-text[data-v-76553c1e], .title[data-v-3ef69486], .price__final[data-v-3ef69486], .operating-system[data-v-3ef69486], .gifter-text[data-v-76553c1e], .user[data-v-41926b43] {
 	color: var(--text3) !important;
 }
 .product-tile-wrapper[data-v-3ef69486] {


### PR DESCRIPTION
![0](https://github.com/pabli24/GOG-Dark/assets/14265316/efd5540e-787d-4528-b5ab-2b5a7b8c3450)