### PR TITLE
Fix owned game card background color in news (and top border one)

### DIFF
--- a/GOG-Dark.user.css
+++ b/GOG-Dark.user.css
@@ -268,6 +268,9 @@ if sb {
 .order__related-games .product-row.is-owned {
 	background: var(--bg3);
 }
+.article__related_topics .product-row:first-child {
+	border-top: 1px solid var(--bg3);
+}
 .product-tile__label--in-library {
 	background: hsla(0, 0%, 10%, 0.7);
 	color: var(--text3);
@@ -910,7 +913,7 @@ img[src="https://items.gog.com/separator.jpg"] {
 .article__related_topics .product-row.product-row--has-action:hover, .article__related_topics .product-row.product-row--has-card.is-owned:hover, .article__related_topics .product-row.product-row--has-card:hover {
 	background: var(--bg-hover);
 }
-.article__related_topics .product-row.is-owned {
+.article__related_topics .product-row.is-owned, .small-spots .product-row.is-owned {
 	background: var(--bg3);
 }
 .btn--gray {


### PR DESCRIPTION
![0](https://github.com/pabli24/GOG-Dark/assets/14265316/23021883-631f-4dfc-a3e7-0be95338da77)