### PR TITLE
Fix background and URL colors in news and support

### DIFF
--- a/GOG-Dark.user.css
+++ b/GOG-Dark.user.css
@@ -881,6 +881,9 @@ img[src="https://items.gog.com/separator.jpg"] {
 .article-section__title, .article__secondary_title {
 	color: text2
 }
+.article__body {
+	background: none
+}
 .article__body a {
 	background-image: linear-gradient(90deg,text1,text1)
 }
@@ -2916,10 +2919,10 @@ select {
 }
 
 /* support.gog.com */
-.article__body {
+body > div.layout > div.layout__main > main > div > div > div:nth-child(2) > div.column.column--sm-8 > article > div.article__body.markdown {
 	background: bg2
 }
-.article__body a {
+body > div.layout > div.layout__main > main > div > div > div:nth-child(2) > div.column.column--sm-8 > article > div.article__body.markdown > p > a, body > div.layout > div.layout__main > main > div > div > div:nth-child(2) > div.column.column--sm-8 > article > div.article__body.markdown > ol > li:nth-child(3) > a, body > div.layout > div.layout__main > main > div > div > div:nth-child(2) > div.column.column--sm-8 > article > div.article__body.markdown > p > span > a, body > div.layout > div.layout__main > main > div > div > div:nth-child(2) > div.column.column--sm-8 > article > div.article__body.markdown > p > strong > span > a {
 	background-image: none
 }
 


### PR DESCRIPTION
https://www.gog.com/news/wolfenstein_bundle_otxo_release_and_gruesome_discounts_all_that_in_our_gore_galore_sale
![0](https://github.com/pabli24/GOG-Dark/assets/14265316/6c555f5e-cd21-4ce1-8609-891b28a2c961)